### PR TITLE
PUB-503 - Exception Handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,11 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.4.5'
+  id 'org.springframework.boot' version '2.3.12.RELEASE'
   id 'org.owasp.dependencycheck' version '6.2.1'
   id 'com.github.ben-manes.versions' version '0.39.0'
   id 'org.sonarqube' version '3.2.0'
+  id 'io.freefair.lombok' version '6.0.0-m2'
 }
 
 group = 'uk.gov.hmcts.reform'
@@ -187,13 +188,10 @@ dependencies {
 
   implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
   implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.8.RELEASE'
+  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.9.RELEASE'
 
   compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.14.1'
   compile group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.14.1'
-
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.0.6'
-  compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.6'
 
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {

--- a/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/ExceptionResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/ExceptionResponse.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.demo.errorhandling;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * Exception Response class, to standardise exceptions returned from the server.
+ */
+@Data
+public class ExceptionResponse {
+
+    /**
+     * The error message to return.
+     */
+    private String message;
+
+    /**
+     * The timestamp of when the error occurred.
+     */
+    private LocalDateTime timestamp;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.demo.errorhandling;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import uk.gov.hmcts.reform.demo.errorhandling.exceptions.ChannelNotFoundException;
+
+import java.time.LocalDateTime;
+
+/**
+ * Global exception handler, that captures exceptions thrown by the controllers, and encapsulates
+ * the logic to handle them and return a standardised response to the user.
+ */
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Template exception handler, that handles a custom ChannelNotFoundException,
+     * and returns a 404 in the standard format.
+     * @param ex The exception that has been thrown.
+     * @param request The request made to the endpoint.
+     * @return The error response, modelled using the ExceptionResponse object.
+     */
+    @ExceptionHandler(ChannelNotFoundException.class)
+    ResponseEntity<ExceptionResponse> handleChannelNotFound(ChannelNotFoundException ex, WebRequest request) {
+
+        ExceptionResponse exceptionResponse = new ExceptionResponse();
+        exceptionResponse.setMessage(ex.getMessage());
+        exceptionResponse.setTimestamp(LocalDateTime.now());
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/exceptions/ChannelNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/demo/errorhandling/exceptions/ChannelNotFoundException.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.demo.errorhandling.exceptions;
+
+/**
+ * Exception that captures the message when a channel is not found.
+ */
+public class ChannelNotFoundException extends RuntimeException {
+
+    private static final long serialVersionUID = 4004263646614654433L;
+
+    /**
+     * Constructor for the Exception.
+     * @param message The message to return to the end user
+     */
+    public ChannelNotFoundException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-503

### Change description ###

This adds in an example of Global Exception handling to the repo, which we can use going forwards to handle exceptions, keeping the controllers and other classes free from needed to know how to deal with exceptions, what status codes to return in each scenario etc.

Example of it can be seen https://www.baeldung.com/exception-handling-for-rest-with-spring, in section 4.

To get the Spring Application to run, I've had to change the version of spring to 2.3.12.RELEASE for now. 2.4.5 doesn't seem to support Hystrix, which now seems to be deprecated.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
