### PR TITLE
Pub 1005 Upgrade log4j2 version to 2.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.5.7'
+  id 'org.springframework.boot' version '2.5.8'
   id 'org.owasp.dependencycheck' version '6.0.3'
   id 'com.github.ben-manes.versions' version '0.39.0'
   id 'org.sonarqube' version '3.0'
@@ -208,4 +208,4 @@ wrapper {
     distributionType = Wrapper.DistributionType.ALL
 }
 
-ext['log4j2.version'] = '2.15.0'
+ext['log4j2.version'] = '2.17.1'


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines

Upgrade log4j2 version to 2.17.1 to fix vulnerability issue.

Please remove this line and everything above and fill the following sections:

https://tools.hmcts.net/jira/browse/PUB-1005


**Does this PR introduce a breaking change?** (check one with "x")
[ ] Yes
[x] No