### PR TITLE
PUB-2309 - Change logging level for PDF generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,6 +202,7 @@ dependencies {
 
   implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.5'
   implementation group: 'com.openhtmltopdf', name: 'openhtmltopdf-pdfbox', version: '1.0.10'
+  implementation group: 'com.openhtmltopdf', name: 'openhtmltopdf-slf4j', version: '1.0.10'
   implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.25.2'
 
   testImplementation group: 'org.springframework.security', name: 'spring-security-test'

--- a/src/main/java/uk/gov/hmcts/reform/pip/channel/management/services/PublicationFileGenerationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/channel/management/services/PublicationFileGenerationService.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.pip.channel.management.services;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.openhtmltopdf.slf4j.Slf4jLogger;
+import com.openhtmltopdf.util.XRLog;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +44,7 @@ public class PublicationFileGenerationService {
                                             ListConversionFactory listConversionFactory) {
         this.dataManagementService = dataManagementService;
         this.listConversionFactory = listConversionFactory;
+        XRLog.setLoggerImpl(new Slf4jLogger());
     }
 
     public static String maskDataSourceName(String provenance) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,3 +58,8 @@ springdoc:
 
 pdf:
   font: /opt/app/openSans.ttf
+
+logging:
+  level:
+    com.openhtmltopdf.match: WARN
+    com.openhtmltopdf.load: WARN


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2309

### Change description ###

Change logging level for PDF generation so that it is not as verbose.

Also updated to use SLF4j so logging style is in line with the rest of the application.

Logging level for errors remain as INFO so that they are shown. The 'using fast-mode renderer' message will still show, as it is grouped together in the same logging category as the errors.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
