### PR TITLE
PUB-2196: Adding organisationDetails to etDaily, etFortnightly, familyDailyCause and iacDaily lists and logic to display details

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pip/channel/management/services/helpers/PartyRoleHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/channel/management/services/helpers/PartyRoleHelper.java
@@ -28,6 +28,7 @@ public final class PartyRoleHelper {
     private static final String INDIVIDUAL_MIDDLE_NAME = "individualMiddleName";
     private static final String INDIVIDUAL_SURNAME = "individualSurname";
     private static final String TITLE = "title";
+    private static final String ORGANISATION_DETAILS = "organisationDetails";
 
     private PartyRoleHelper() {
     }
@@ -78,8 +79,13 @@ public final class PartyRoleHelper {
     }
 
     private static void formatPartyDetails(JsonNode party, StringBuilder builder, boolean initialised) {
-        String details = createIndividualDetails(party, initialised);
-        formatPartyDetails(builder, details);
+        if (party.has(INDIVIDUAL_DETAILS)) {
+            String details = createIndividualDetails(party, initialised);
+            formatPartyDetails(builder, details);
+        } else if (party.has(ORGANISATION_DETAILS)) {
+            String details = createOrganisationDetails(party);
+            formatPartyDetails(builder, details);
+        }
     }
 
     public static void formatPartyDetails(StringBuilder builder, String details) {

--- a/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/artefactsummary/EtDailyListSummaryConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/artefactsummary/EtDailyListSummaryConverterTest.java
@@ -41,12 +41,20 @@ class EtDailyListSummaryConverterTest {
             .contains("Case Number: 12341234");
 
         softly.assertThat(output)
-            .as("Incorrect claimant")
+            .as("Incorrect individual claimant")
             .contains("Claimant: Mr T Test Surname");
 
         softly.assertThat(output)
-            .as("Incorrect respondent")
+            .as("Incorrect individual respondent")
             .contains("Capt. T Test Surname 2");
+
+        softly.assertThat(output)
+            .as("Incorrect organisation claimant")
+            .contains("Claimant: Organisation Name");
+
+        softly.assertThat(output)
+            .as("Incorrect organisation respondent")
+            .contains("Respondent: Organisation Name");
 
         softly.assertThat(output)
             .as("Incorrect hearing type")

--- a/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/artefactsummary/EtFortnightlyPressListSummaryConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/artefactsummary/EtFortnightlyPressListSummaryConverterTest.java
@@ -53,12 +53,16 @@ class EtFortnightlyPressListSummaryConverterTest {
             .contains("12341234");
 
         softly.assertThat(emailOutput)
-            .as("incorrect Claimant found")
+            .as("Incorrect individual claimant")
             .contains("Rep: Mr T Test Surname 2");
 
         softly.assertThat(emailOutput)
-            .as("incorrect Respondent found")
+            .as("Incorrect individual respondent")
             .contains("Capt. T Test Surname");
+
+        softly.assertThat(emailOutput)
+            .as("Incorrect organisation claimant")
+            .contains("Claimant - Organisation Name, Rep: Organisation Name");
 
         softly.assertThat(emailOutput)
             .as("incorrect hearing type found")

--- a/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/artefactsummary/IacDailyListSummaryConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/artefactsummary/IacDailyListSummaryConverterTest.java
@@ -57,8 +57,12 @@ class IacDailyListSummaryConverterTest {
             .contains("VIDEO HEARING");
 
         softly.assertThat(artefactSummary)
-            .as("incorrect claimant found")
+            .as("incorrect individual claimant found")
             .contains("Surname");
+
+        softly.assertThat(artefactSummary)
+            .as("incorrect organisation claimant found")
+            .contains("Organisation Name");
 
         softly.assertThat(artefactSummary)
             .as("incorrect prosecuting authority found")

--- a/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/filegeneration/EtDailyListFileConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/filegeneration/EtDailyListFileConverterTest.java
@@ -94,6 +94,17 @@ class EtDailyListFileConverterTest {
                         "This is a sitting channel"
             );
 
+        softly.assertThat(doc.getElementsByClass("govuk-table__body").get(1).getElementsByTag("td"))
+            .as("Incorrect table contents for organisation details")
+            .hasSize(14)
+            .extracting(Element::text)
+            .startsWith("9:30am",
+                      "3 mins",
+                      "12341234",
+                      "Organisation Name",
+                      "Organisation Name",
+                      "Hearing Type 1");
+
         softly.assertAll();
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/filegeneration/EtFortnightlyPressListFileConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/filegeneration/EtFortnightlyPressListFileConverterTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -69,6 +70,30 @@ class EtFortnightlyPressListFileConverterTest {
         assertThat(document.getElementsByClass("govuk-body")
                        .get(2).text())
             .as(HEADER_TEXT).contains("5 Test Street");
+
+        assertThat(document.getElementsByTag("td"))
+            .as("Incorrect table contents")
+            .hasSize(42)
+            .extracting(Element::text)
+            .startsWith("9:30am",
+                        "2 hours [2 of 3]",
+                        "12341234",
+                        "Rep: Mr T Test Surname 2",
+                        "Capt. T Test Surname Rep: Dr T Test Surname 2",
+                        "This is a hearing type",
+                        "This is a sitting channel"
+            );
+
+        assertThat(document.getElementsByClass("govuk-table__body").get(1).getElementsByTag("td"))
+            .as("Incorrect table contents for organisation details")
+            .hasSize(35)
+            .extracting(Element::text)
+            .startsWith("3:30pm",
+                        "3 mins",
+                        "12341234",
+                        "Organisation Name Rep: Organisation Name",
+                        "Lord T Test Surname Rep: Dame T Test Surname",
+                        "Hearing Type 1");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/filegeneration/FamilyCauseListFileConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/filegeneration/FamilyCauseListFileConverterTest.java
@@ -189,6 +189,21 @@ class FamilyCauseListFileConverterTest {
                 "Respondent Surname 2"
             );
 
+        softly.assertThat(doc.getElementsByClass("govuk-table__body").get(1).getElementsByTag("td"))
+            .as("Incorrect table contents for hearing with organisation details")
+            .extracting(Element::text)
+            .containsSequence(
+                "10:30am",
+                "12341235",
+                "This is a case name 2",
+                "normal",
+                "Directions",
+                "Teams, Attended",
+                "1 hour 25 mins",
+                "Applicant org name, Legal Advisor: Applicant rep org name",
+                "Respondent org name, Legal Advisor: Respondent rep org name"
+            );
+
         softly.assertAll();
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/filegeneration/IacDailyListFileConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/filegeneration/IacDailyListFileConverterTest.java
@@ -119,8 +119,8 @@ class IacDailyListFileConverterTest {
             .extracting(Element::text)
             .contains("9:00pm",
                       CASE_REF,
-                      "Surname Rep: Mr Individual Forenames Individual Surname",
-                      RESPONDENT,
+                      "Organisation Name Rep: Organisation Name",
+                      "Organisation Name",
                       "French",
                       "VIDEO HEARING",
                       "1234");

--- a/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/helpers/listmanipulation/FamilyMixedListHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/channel/management/services/helpers/listmanipulation/FamilyMixedListHelperTest.java
@@ -172,12 +172,12 @@ class FamilyMixedListHelperTest {
     void testGetPartyWithOrganisationDetails() {
         FamilyMixedListHelper.manipulatedlistData(inputJson, Language.ENGLISH);
 
-        JsonNode hearingCase = inputJson.get(COURT_LISTS).get(0)
+        JsonNode hearingCase = inputJson.get(COURT_LISTS).get(1)
             .get(COURT_HOUSE)
             .get(COURT_ROOM).get(0)
             .get(SESSION).get(0)
             .get(SITTINGS).get(0)
-            .get(HEARING).get(1)
+            .get(HEARING).get(0)
             .get(CASE).get(0);
 
         SoftAssertions softly = new SoftAssertions();

--- a/src/test/resources/mocks/etDailyList.json
+++ b/src/test/resources/mocks/etDailyList.json
@@ -82,18 +82,30 @@
                   "party": [
                     {
                       "partyRole": "CLAIMANT_PETITIONER",
-                      "individualDetails": {
-                        "title": "Ms",
-                        "individualForenames": "Test forename",
-                        "individualSurname": "Test Surname"
+                      "organisationDetails": {
+                        "organisationName": "Organisation Name",
+                        "organisationAddress": {
+                          "line": [
+                            "ORGANISATION ADDRESS"
+                          ],
+                          "town": "town name",
+                          "county": "",
+                          "postCode": ""
+                        }
                       }
                     },
                     {
                       "partyRole": "RESPONDENT",
-                      "individualDetails": {
-                        "title": "Lord",
-                        "individualForenames": "Test forename",
-                        "individualSurname": "Test Surname"
+                      "organisationDetails": {
+                        "organisationName": "Organisation Name",
+                        "organisationAddress": {
+                          "line": [
+                            "ORGANISATION ADDRESS"
+                          ],
+                          "town": "town name",
+                          "county": "",
+                          "postCode": ""
+                        }
                       },
                       "friendlyRoleName": "This is a role name"
                     }

--- a/src/test/resources/mocks/etFortnightlyPressList.json
+++ b/src/test/resources/mocks/etFortnightlyPressList.json
@@ -94,18 +94,30 @@
                   "caseNumber": "12341234",
                   "party": [{
                     "partyRole": "CLAIMANT_PETITIONER",
-                    "individualDetails": {
-                      "title": "Ms",
-                      "individualForenames": "Test forename",
-                      "individualSurname": "Test Surname"
+                    "organisationDetails": {
+                      "organisationName": "Organisation Name",
+                      "organisationAddress": {
+                        "line": [
+                          "ORGANISATION ADDRESS"
+                        ],
+                        "town": "town name",
+                        "county": "",
+                        "postCode": ""
+                      }
                     }
                   },
                     {
                       "partyRole": "CLAIMANT_PETITIONER_REPRESENTATIVE",
-                      "individualDetails": {
-                        "title": "Sir",
-                        "individualForenames": "Test forename",
-                        "individualSurname": "Test Surname"
+                      "organisationDetails": {
+                        "organisationName": "Organisation Name",
+                        "organisationAddress": {
+                          "line": [
+                            "ORGANISATION ADDRESS"
+                          ],
+                          "town": "town name",
+                          "county": "",
+                          "postCode": ""
+                        }
                       },
                       "friendlyRoleName": "This is a role name"
                     },

--- a/src/test/resources/mocks/familyDailyCauseList.json
+++ b/src/test/resources/mocks/familyDailyCauseList.json
@@ -93,84 +93,6 @@
                         "hearingType": "Directions",
                         "case": [
                           {
-                            "caseName": "This is a case name 2",
-                            "caseNumber": "12341235",
-                            "caseType": "normal",
-                            "party": [
-                              {
-                                "partyRole": "APPLICANT_PETITIONER",
-                                "organisationDetails": {
-                                  "organisationName": "Applicant org name"
-                                }
-                              },
-                              {
-                                "partyRole": "RESPONDENT",
-                                "organisationDetails": {
-                                  "organisationName": "Respondent org name"
-                                }
-                              },
-                              {
-                                "partyRole": "APPLICANT_PETITIONER_REPRESENTATIVE",
-                                "friendlyRoleName": "Legal Advisor",
-                                "organisationDetails": {
-                                  "organisationName": "Applicant rep org name"
-                                }
-                              },
-                              {
-                                "partyRole": "RESPONDENT_REPRESENTATIVE",
-                                "friendlyRoleName": "Legal Advisor",
-                                "organisationDetails": {
-                                  "organisationName": "Respondent rep org name"
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ],
-                    "channel": [
-                      "Teams",
-                      "Attended"
-                    ]
-                  }
-                ],
-                "judiciary": [
-                  {
-                    "isPresiding": true,
-                    "johKnownAs": "Judge KnownAs Presiding"
-                  },
-                  {
-                    "isPresiding": false,
-                    "johKnownAs": "Judge KnownAs"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "courtHouse": {
-        "courtHouseName": "This is the site name",
-        "courtHouseContact": {
-          "venueTelephone": "01234 123 123",
-          "venueEmail": "a@b.com"
-        },
-        "courtRoom": [
-          {
-            "courtRoomName": "This is the court room name",
-            "session": [
-              {
-                "sittings": [
-                  {
-                    "sittingStart": "2022-08-19T09:30:00Z",
-                    "sittingEnd": "2022-08-19T10:55:00Z",
-                    "hearing": [
-                      {
-                        "hearingType": "Directions",
-                        "case": [
-                          {
                             "caseName": "This is a case name 3",
                             "caseNumber": "12341236",
                             "caseType": "normal",
@@ -244,6 +166,84 @@
                                   "individualMiddleName": "Rep Middlename 4",
                                   "individualSurname": "Rep Surname 4",
                                   "title": "Mr"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "channel": [
+                      "Teams",
+                      "Attended"
+                    ]
+                  }
+                ],
+                "judiciary": [
+                  {
+                    "isPresiding": true,
+                    "johKnownAs": "Judge KnownAs Presiding"
+                  },
+                  {
+                    "isPresiding": false,
+                    "johKnownAs": "Judge KnownAs"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "courtHouse": {
+        "courtHouseName": "This is the site name",
+        "courtHouseContact": {
+          "venueTelephone": "01234 123 123",
+          "venueEmail": "a@b.com"
+        },
+        "courtRoom": [
+          {
+            "courtRoomName": "This is the court room name",
+            "session": [
+              {
+                "sittings": [
+                  {
+                    "sittingStart": "2022-08-19T09:30:00Z",
+                    "sittingEnd": "2022-08-19T10:55:00Z",
+                    "hearing": [
+                      {
+                        "hearingType": "Directions",
+                        "case": [
+                          {
+                            "caseName": "This is a case name 2",
+                            "caseNumber": "12341235",
+                            "caseType": "normal",
+                            "party": [
+                              {
+                                "partyRole": "APPLICANT_PETITIONER",
+                                "organisationDetails": {
+                                  "organisationName": "Applicant org name"
+                                }
+                              },
+                              {
+                                "partyRole": "RESPONDENT",
+                                "organisationDetails": {
+                                  "organisationName": "Respondent org name"
+                                }
+                              },
+                              {
+                                "partyRole": "APPLICANT_PETITIONER_REPRESENTATIVE",
+                                "friendlyRoleName": "Legal Advisor",
+                                "organisationDetails": {
+                                  "organisationName": "Applicant rep org name"
+                                }
+                              },
+                              {
+                                "partyRole": "RESPONDENT_REPRESENTATIVE",
+                                "friendlyRoleName": "Legal Advisor",
+                                "organisationDetails": {
+                                  "organisationName": "Respondent rep org name"
                                 }
                               }
                             ]

--- a/src/test/resources/mocks/iacDailyList.json
+++ b/src/test/resources/mocks/iacDailyList.json
@@ -131,30 +131,58 @@
                             "party": [
                               {
                                 "partyRole": "CLAIMANT_PETITIONER",
-                                "individualDetails": {
-                                  "individualSurname": "Surname"
+                                "organisationDetails": {
+                                  "organisationName": "Organisation Name",
+                                  "organisationAddress": {
+                                    "line": [
+                                      "ORGANISATION ADDRESS"
+                                    ],
+                                    "town": "town name",
+                                    "county": "",
+                                    "postCode": ""
+                                  }
                                 }
                               },
                               {
                                 "partyRole": "RESPONDENT",
-                                "individualDetails": {
-                                  "individualSurname": "Authority Surname"
+                                "organisationDetails": {
+                                  "organisationName": "Organisation Name",
+                                  "organisationAddress": {
+                                    "line": [
+                                      "ORGANISATION ADDRESS"
+                                    ],
+                                    "town": "town name",
+                                    "county": "",
+                                    "postCode": ""
+                                  }
                                 }
                               },
                               {
                                 "partyRole": "CLAIMANT_PETITIONER_REPRESENTATIVE",
-                                "individualDetails": {
-                                  "individualForenames": "Individual Forenames",
-                                  "individualSurname": "Individual Surname",
-                                  "title": "Mr"
+                                "organisationDetails": {
+                                  "organisationName": "Organisation Name",
+                                  "organisationAddress": {
+                                    "line": [
+                                      "ORGANISATION ADDRESS"
+                                    ],
+                                    "town": "town name",
+                                    "county": "",
+                                    "postCode": ""
+                                  }
                                 }
                               },
                               {
                                 "partyRole": "RESPONDENT_REPRESENTATIVE",
-                                "individualDetails": {
-                                  "individualForenames": "Individual Forenames",
-                                  "individualSurname": "Individual Surname",
-                                  "title": "Mr"
+                                "organisationDetails": {
+                                  "organisationName": "Organisation Name",
+                                  "organisationAddress": {
+                                    "line": [
+                                      "ORGANISATION ADDRESS"
+                                    ],
+                                    "town": "town name",
+                                    "county": "",
+                                    "postCode": ""
+                                  }
                                 }
                               }
                             ]


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PUB-2196



Adding organisationDetails to etDaily, etFortnightly, familyDailyCause and iacDaily lists and logic to display details



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
